### PR TITLE
Parse command line to allow starting fullscreen

### DIFF
--- a/flukeEmuWx/FlukeEmuWxApp.cpp
+++ b/flukeEmuWx/FlukeEmuWxApp.cpp
@@ -28,12 +28,25 @@ wxIMPLEMENT_APP(FlukeEmuWxApp);
 
 bool FlukeEmuWxApp::OnInit()
 {
+    if (!wxApp::OnInit())
+        return false;
     // Log window
     //wxLogWindow* logWnd = new wxLogWindow(NULL, "FlukeEmuLog", true, false);
     //logWnd->SetActiveTarget(logWnd);
-    FlukeEmuWxFrame* frame = new FlukeEmuWxFrame(0L, _("FlukeEmWx"));
+    FlukeEmuWxFrame* frame = new FlukeEmuWxFrame(0L, _("FlukeEmWx"), fullscreen);
     wxLogDebug("FlukeEmuWx LOG started\n");
     //frame->SetIcon(wxICON(aaaa)); // To Set App Icon
     frame->Show();
+    return true;
+}
+
+void FlukeEmuWxApp::OnInitCmdLine(wxCmdLineParser& parser)
+{
+    parser.SetDesc (g_cmdLineDesc);
+}
+
+bool FlukeEmuWxApp::OnCmdLineParsed(wxCmdLineParser& parser)
+{
+    fullscreen = parser.Found(wxT("f"));
     return true;
 }

--- a/flukeEmuWx/FlukeEmuWxApp.h
+++ b/flukeEmuWx/FlukeEmuWxApp.h
@@ -17,13 +17,24 @@ Boston, MA 02111-1307 USA
 #define WXWFLUKEEMUAPP_H
 
 #include <wx/app.h>
+#include <wx/cmdline.h>
 
 class FlukeEmuWxApp : public wxApp
 {
     public:
         virtual bool OnInit();
+        virtual void OnInitCmdLine(wxCmdLineParser& parser);
+        virtual bool OnCmdLineParsed(wxCmdLineParser& parser);
+        
+    private:
+        bool fullscreen;
 
+};
 
+static const wxCmdLineEntryDesc g_cmdLineDesc [] =
+{
+    { wxCMD_LINE_SWITCH, "f", "fullscreen", "start fullscreen" },
+    { wxCMD_LINE_NONE }
 };
 
 #endif // WXWFLUKEEMUAPP_H

--- a/flukeEmuWx/FlukeEmuWxMain.cpp
+++ b/flukeEmuWx/FlukeEmuWxMain.cpp
@@ -96,8 +96,8 @@ BEGIN_EVENT_TABLE(FlukeEmuWxFrame, wxFrame)
     EVT_MOUSE_EVENTS(FlukeEmuWxFrame::OnMouseEvent)
 END_EVENT_TABLE()
 
-FlukeEmuWxFrame::FlukeEmuWxFrame(wxFrame *frame, const wxString& title)
-    : wxFrame(frame, -1, title)
+FlukeEmuWxFrame::FlukeEmuWxFrame(wxFrame *frame, const wxString& title, bool fullscreen)
+    : wxFrame(frame, -1, title), m_fullScreen(fullscreen)
 {
     // create a menu bar
     wxMenuBar* mbar = new wxMenuBar();
@@ -139,7 +139,7 @@ FlukeEmuWxFrame::FlukeEmuWxFrame(wxFrame *frame, const wxString& title)
     m_Emu->Bind(wxEVT_LEFT_DOWN, &FlukeEmuWxFrame::OnMouseEvent, this);
 
     Fit();
-    m_fullScreen = false;
+    ShowFullScreen(m_fullScreen, wxFULLSCREEN_ALL);
 }
 
 

--- a/flukeEmuWx/FlukeEmuWxMain.h
+++ b/flukeEmuWx/FlukeEmuWxMain.h
@@ -24,7 +24,7 @@ Boston, MA 02111-1307 USA
 class FlukeEmuWxFrame: public wxFrame
 {
     public:
-        FlukeEmuWxFrame(wxFrame *frame, const wxString& title);
+        FlukeEmuWxFrame(wxFrame *frame, const wxString& title, bool fullscreen);
         ~FlukeEmuWxFrame();
 
     private:


### PR DESCRIPTION
This allows starting the app fullscreen by starting it with the -f option.